### PR TITLE
correct missing 'msg' for report.verbose call

### DIFF
--- a/cmsmap.py
+++ b/cmsmap.py
@@ -1511,7 +1511,7 @@ class PostExploit:
                             # shell found then exit
                             sys.exit()
                 else:
-                    msg = "Not Writable Joomla template: "+ template[0]; report.verbose()
+                    msg = "Not Writable Joomla template: "+ template[0]; report.verbose(msg)
                 
         except urllib2.HTTPError, e:
             # print e.code


### PR DESCRIPTION
pylint --errors-only cmsmap.py
[...]
E:1514,73:PostExploit.JooWritableTemplate: No value passed for parameter 'msg' in function call