### PR TITLE
fix for UnboundLocalError: local variable 'htmltext' referenced before a...

### DIFF
--- a/cmsmap.py
+++ b/cmsmap.py
@@ -208,7 +208,7 @@ class Scanner:
             GenericChecks(self.url).HTTPSCheck()
             GenericChecks(self.url).HeadersCheck()
             GenericChecks(self.url).RobotsTXT()
-
+            htmltext = ''
             # WordPress
             req = urllib2.Request(self.url+"/wp-config.php") 
             try:


### PR DESCRIPTION
fix for https://github.com/Dionach/CMSmap/issues/38 and https://github.com/Dionach/CMSmap/issues/30

```
Traceback (most recent call last):
  File "./cmsmap.py", line 1971, in <module>
    scanner.FindCMSType()
  File "./cmsmap.py", line 220, in FindCMSType
    if e.code == 403 and len(htmltext) not in self.notValidLen and not self.CMSFound:
UnboundLocalError: local variable 'htmltext' referenced before assignment
```